### PR TITLE
Fix instructions for update-deps nox session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -195,7 +195,7 @@ def update_deps(session: nox.Session) -> None:
         "server/requirements/dev.in",
     )
 
-    print("\nTo refresh the development venv, run:\n\n\tnox -s dev-init\n")
+    print("\nTo refresh the development venv, run:\n\n\tnox -s init\n")
 
 
 @nox.session(name="run")


### PR DESCRIPTION
The session to refresh the current env is just "init" now.