### PR TITLE
Fix nox -s init command

### DIFF
--- a/changelog.d/20230629_160229_jsick_fix_init.md
+++ b/changelog.d/20230629_160229_jsick_fix_init.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fixed the `nox -s init` command so that it will install into the current Python environment (previously it still installing into the environment managed by `nox`).

--- a/noxfile.py
+++ b/noxfile.py
@@ -69,7 +69,7 @@ def init_dev(session: nox.Session) -> None:
     )
 
 
-@nox.session(name="init")
+@nox.session(name="init", python=False)
 def init(session: nox.Session) -> None:
     """Set up the development environment in the current virtual env."""
     _install_dev(session, bin_prefix="")


### PR DESCRIPTION
Python=False essentially ensures a venv isn't created for the nox
session. This ensures that the installation uses the terminal session's
Python.