### PR TITLE
Fix command for updating dependencies

### DIFF
--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -35,7 +35,8 @@ jobs:
           pip install --upgrade uv
           uv venv
           source .venv/bin/activate
-          make update-deps
+          uv pip install nox
+          nox -s update-deps
         shell: bash
 
       - name: Start Kafka


### PR DESCRIPTION
With the move to nox, this command is `nox -s update-deps`, and not `make update-deps`.

This should fix the periodic-ci.yaml workflow.