### PR TITLE
DM-45917: Configure URL for hosting async api schema and doc

### DIFF
--- a/changelog.d/20240926_135225_jsick_DM_45917.md
+++ b/changelog.d/20240926_135225_jsick_DM_45917.md
@@ -1,0 +1,3 @@
+### New features
+
+- Publish AsyncAPI documentation to the `/asyncapi` endpoint. This documentation site is generated automatically through Faststream.

--- a/server/src/squarebot/factory.py
+++ b/server/src/squarebot/factory.py
@@ -45,21 +45,21 @@ class ProcessContext:
             kafka_broker=broker,
             channel_publisher=broker.publisher(
                 config.message_channels_topic,
-                title="Slack public channel messages.",
+                description="Slack public channel messages.",
             ),
             im_publisher=broker.publisher(
-                config.message_im_topic, title="Slack IM messages."
+                config.message_im_topic, description="Slack IM messages."
             ),
             mpim_publisher=broker.publisher(
-                config.message_mpim_topic, title="Slack MPIM messages."
+                config.message_mpim_topic, description="Slack MPIM messages."
             ),
             groups_publisher=broker.publisher(
                 config.message_groups_topic,
-                title="Slack private-channel messages.",
+                description="Slack private-channel messages.",
             ),
             app_mentions_publisher=broker.publisher(
                 config.app_mention_topic,
-                title="Slack bot mention messages.",
+                description="Slack bot mention messages.",
             ),
         )
 

--- a/server/src/squarebot/kafkarouter.py
+++ b/server/src/squarebot/kafkarouter.py
@@ -12,5 +12,7 @@ __all__ = ["kafka_router"]
 
 kafka_security = BaseSecurity(ssl_context=config.kafka.ssl_context)
 kafka_router = KafkaRouter(
-    config.kafka.bootstrap_servers, security=kafka_security
+    config.kafka.bootstrap_servers,
+    security=kafka_security,
+    schema_url=f"{config.path_prefix}/asyncapi",
 )


### PR DESCRIPTION
The documentation should be available at `/squarebot/asyncapi` and the JSON/YAML representation of the asyncapi spec should be at `/squarebot/asyncapi.[json|yaml]`