### PR TITLE
DM-46413: Fix setting the SquarebotSlackMessage.is_bot field

### DIFF
--- a/changelog.d/20240919_190157_jsick_DM_46413.md
+++ b/changelog.d/20240919_190157_jsick_DM_46413.md
@@ -6,7 +6,7 @@
 
 ### New features
 
--
+- Added `SquarebotSlackMessageValue.bot_id` to capture the ID of the app that send a bot message.
 
 ### Bug fixes
 

--- a/changelog.d/20240919_190157_jsick_DM_46413.md
+++ b/changelog.d/20240919_190157_jsick_DM_46413.md
@@ -1,0 +1,17 @@
+<!-- Delete the sections that don't apply -->
+
+### Backwards-incompatible changes
+
+- `SquarebotSlackMessageValue.user` is now nullable. It will be `null` if the message is a `bot_message` subtype.
+
+### New features
+
+-
+
+### Bug fixes
+
+- Fix setting the `is_bot` property of `SquarebotSlackMessageValue` to account for messages without the `bot_message` subtype, but which still have a `bot_id` set.
+
+### Other changes
+
+-

--- a/client/src/rubin/squarebot/models/kafka.py
+++ b/client/src/rubin/squarebot/models/kafka.py
@@ -77,6 +77,14 @@ class SquarebotSlackMessageValue(BaseModel):
         ),
     )
 
+    bot_id: str | None = Field(
+        None,
+        description=(
+            "The ID of the Slack App integration that sent the message. This "
+            "is null for non-bot messages."
+        ),
+    )
+
     ts: str = Field(
         ...,
         description=(
@@ -152,6 +160,7 @@ class SquarebotSlackMessageValue(BaseModel):
             channel=event.event.channel,
             channel_type=event.event.channel_type,
             user=event.event.user,
+            bot_id=event.event.bot_id,
             ts=event.event.ts,
             thread_ts=event.event.thread_ts,
             text=event.event.combined_text_content,

--- a/client/src/rubin/squarebot/models/kafka.py
+++ b/client/src/rubin/squarebot/models/kafka.py
@@ -68,11 +68,12 @@ class SquarebotSlackMessageValue(BaseModel):
         ..., description="The Slack channel type."
     )
 
-    user: str = Field(
-        ...,
+    user: str | None = Field(
+        None,
         description=(
             "The ID of the user or bot that sent the message. See the "
-            "is_bot field to determine if the user is a bot."
+            "is_bot field to determine if the user is a bot. For bot_message "
+            "subtypes this may be null."
         ),
     )
 
@@ -126,6 +127,8 @@ class SquarebotSlackMessageValue(BaseModel):
                 "event that lacks a channel_type. Is this an app_mention?"
             )
 
+        is_bot = False
+
         if (
             event.event.subtype is not None
             and event.event.subtype == SlackMessageSubtype.bot_message
@@ -136,21 +139,19 @@ class SquarebotSlackMessageValue(BaseModel):
                     "Cannot create a SquarebotSlackMessageValue from a Slack "
                     "bot_message event that lacks a bot_id."
                 )
-            user_id = event.event.bot_id
-        else:
-            is_bot = False
-            if event.event.user is None:
-                raise ValueError(
-                    "Cannot create a SquarebotSlackMessageValue from a Slack "
-                    "message event that lacks a user."
-                )
-            user_id = event.event.user
+        elif event.event.bot_id is not None:
+            is_bot = True
+        elif event.event.user is None:
+            raise ValueError(
+                "Cannot create a SquarebotSlackMessageValue from a Slack "
+                "message event that lacks a user if not a bot message."
+            )
 
         return cls(
             type=event.event.type,
             channel=event.event.channel,
             channel_type=event.event.channel_type,
-            user=user_id,
+            user=event.event.user,
             ts=event.event.ts,
             thread_ts=event.event.thread_ts,
             text=event.event.combined_text_content,


### PR DESCRIPTION
### Backwards-incompatible changes

- `SquarebotSlackMessageValue.user` is now nullable. It will be `null` if the message is a `bot_message` subtype.

### New features

- Added `SquarebotSlackMessageValue.bot_id` to capture the ID of the app that send a bot message.

### Bug fixes

- Fix setting the `is_bot` property of `SquarebotSlackMessageValue` to account for messages without the `bot_message` subtype, but which still have a `bot_id` set.