### PR TITLE
DM-52018: Remove environment_url from configuration

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -55,7 +55,6 @@ def _make_env_vars() -> dict[str, str]:
     """
     return {
         "SQUAREBOT_LOG_LEVEL": "DEBUG",
-        "SQUAREBOT_ENVIRONMENT_URL": "http://example.org",
         "KAFKA_BOOTSTRAP_SERVERS": "localhost:9092",
         "KAFKA_SECURITY_PROTOCOL": "PLAINTEXT",
         "SQUAREBOT_SLACK_SIGNING": "1234",

--- a/server/src/squarebot/config.py
+++ b/server/src/squarebot/config.py
@@ -6,7 +6,7 @@ import ssl
 from enum import Enum
 from pathlib import Path
 
-from pydantic import AnyHttpUrl, DirectoryPath, Field, FilePath, SecretStr
+from pydantic import DirectoryPath, Field, FilePath, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from safir.logging import LogLevel, Profile
 
@@ -221,14 +221,6 @@ class Configuration(BaseSettings):
         description=(
             "The URL prefix where the application's externally-accessible "
             "endpoints are hosted."
-        ),
-    )
-
-    environment_url: AnyHttpUrl = Field(
-        ...,
-        title="Base URL of the environment",
-        description=(
-            "The base URL of the environment where the application is hosted."
         ),
     )
 


### PR DESCRIPTION
Remove `Configuration.environment_url` from the SQuaRE Bot configuration. It was not used anywhere.

(I ran into this as a false positive while cataloging service discovery use cases.)