### PR TITLE
DM-51754: Fix PyPI publish for the uv workspace layout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,11 +157,18 @@ jobs:
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
-      - name: Build and publish
-        uses: lsst-sqre/build-and-publish-to-pypi@v3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
-          upload: "false"
-          working-directory: "client"
+          version: ${{ env.UV_VERSION }}
+
+      # rubin-squarebot is a uv workspace member, so build it by name from the
+      # workspace root. uv writes a workspace member's artifacts to the root
+      # dist/, so this can't use the build-and-publish-to-pypi action with
+      # working-directory=client (the action's publish step would look in
+      # client/dist/ and find nothing).
+      - name: Build the client package
+        run: uv build --no-sources --package rubin-squarebot
 
   pypi-publish:
     name: Upload release to PyPI
@@ -178,7 +185,18 @@ jobs:
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
-      - name: Build and publish
-        uses: lsst-sqre/build-and-publish-to-pypi@v3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
-          working-directory: "client"
+          version: ${{ env.UV_VERSION }}
+
+      # rubin-squarebot is a uv workspace member, so build it by name from the
+      # workspace root. uv writes a workspace member's artifacts to the root
+      # dist/ where uv publish looks; building from working-directory=client
+      # would emit to the root dist/ but publish from client/dist/ and find
+      # nothing (which is why the 0.10.1 release failed to upload to PyPI).
+      - name: Build the client package
+        run: uv build --no-sources --package rubin-squarebot
+
+      - name: Publish to PyPI
+        run: uv publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.10.2'></a>
+## 0.10.2 (2026-06-19)
+
+### Other changes
+
+- Fixed the PyPI publish workflow for the uv workspace layout. The `rubin-squarebot` client is a uv workspace member, and `uv build` writes a member's artifacts to the workspace-root `dist/`. The release workflow now builds the client by name from the workspace root (`uv build --no-sources --package rubin-squarebot`) and publishes from there, rather than running the build-and-publish action in `client/`, where `uv publish` looked in `client/dist/` and found nothing. This is why the `rubin-squarebot` 0.10.1 client failed to upload to PyPI; 0.10.2 is the first PyPI release on the modernized uv-workspace layout.
+
 <a id='changelog-0.10.1'></a>
 ## 0.10.1 (2026-06-19)
 


### PR DESCRIPTION
## Summary

- Fix the `rubin-squarebot` client PyPI publish, which silently failed in the 0.10.1 release. In the uv workspace, `uv build` writes a workspace member's artifacts to the workspace-root `dist/`, but the release ran the `build-and-publish-to-pypi` action with `working-directory: client`, so `uv publish` looked in the (empty) `client/dist/` and uploaded nothing — the Docker image and tag shipped 0.10.1 but PyPI never got it.
- Build the client by name from the workspace root (`uv build --no-sources --package rubin-squarebot`) and publish from there in both the `test-package` and `pypi-publish` jobs, so the build output and the publish step agree on the `dist/` location.

## Validation steps

- After this merges and the `0.10.2` tag is pushed, confirm the `pypi-publish` job uploads `rubin-squarebot` and that https://pypi.org/project/rubin-squarebot/ lists `0.10.2`.

## References

- PRD: #36
- Jira: https://rubinobs.atlassian.net/browse/DM-51754

https://claude.ai/code/session_01VjAAFQY6nVnYDNydHgMQrW