### PR TITLE
DM-51754: Run Docker build (no push) for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,16 +137,19 @@ jobs:
     uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v4
     with:
       images: ghcr.io/${{ github.repository }}
+      # Build but don't push for dependabot PRs: no registry secrets are
+      # available and we don't want dependency-bump images in the registry.
+      push: >-
+        ${{ (github.event_name == 'release' && github.event.action == 'published')
+            || startsWith(github.head_ref, 'tickets/') }}
 
-    # Only do Docker builds of tagged releases and pull requests from ticket
-    # branches.  This will still trigger on pull requests from untrusted
-    # repositories whose branch names match our tickets/* branch convention,
-    # but in this case the build will fail with an error since the secret
-    # won't be set.
+    # Build on releases, ticket-branch PRs (build + push), and dependabot PRs
+    # (build only) so the required "build / manifest" check is reported.
     if: >
       (github.event_name == 'release' && github.event.action == 'published')
       || (github.event_name != 'merge_group'
-          && startsWith(github.head_ref, 'tickets/'))
+          && (startsWith(github.head_ref, 'tickets/')
+              || startsWith(github.head_ref, 'dependabot/')))
 
   test-package:
     name: Test PyPI package build

--- a/changelog.d/20260622_000000_jsick_DM_51754.md
+++ b/changelog.d/20260622_000000_jsick_DM_51754.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- The CI `build` job now also runs (without pushing images) for `dependabot/**` pull requests. Previously the Docker build only ran for `tickets/**` branches and releases, so the required `build / manifest` status check was never reported on dependabot PRs and they could not be merged. The reusable build workflow is now passed an explicit `push` expression that is `true` only for tagged releases and `tickets/**` branches, so dependabot PRs build the Dockerfile on both architectures (real coverage for base-image bumps) while the `manifest` job is skipped — satisfying the required check without pushing images or needing registry secrets.


### PR DESCRIPTION
## Summary

- Run the CI Docker build (without pushing) for `dependabot/**` PRs so the required `build / manifest` status check is reported and dependabot PRs become auto-mergeable. Previously the `build` job only ran for `tickets/**` branches and releases, so `build / manifest` was never reported on dependabot PRs and they stayed blocked by the `main` ruleset.
- Pass `push` to the reusable build workflow as an expression that is `true` only for tagged releases and `tickets/**` branches. Dependabot PRs build the Dockerfile on both arches (real coverage for base-image bumps) while the push-gated `manifest` job is skipped — which the ruleset treats as passing — so no images are pushed and no registry secrets are required. Release and ticket-branch behavior is unchanged (still build + push).

## Validation steps

- On the next real `dependabot/**` PR, confirm the `build / containers` job builds the Dockerfile on both architectures and `build / manifest` reports a `skipped` (passing) conclusion, with no image pushed to the registry.
- Confirm a `tickets/**` PR still builds **and** pushes the image and that `build / manifest` runs (behavior unchanged from before).

## References

- Closes #47
- PRD: #36
- Jira: https://rubinobs.atlassian.net/browse/DM-51754