### PR TITLE
DM-55493: collect changelog for 0.10.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.10.3'></a>
+## 0.10.3 (2026-07-20)
+
+### Other changes
+
+- The CI `build` job now also runs (without pushing images) for `dependabot/**` pull requests. Previously the Docker build only ran for `tickets/**` branches and releases, so the required `build / manifest` status check was never reported on dependabot PRs and they could not be merged. The reusable build workflow is now passed an explicit `push` expression that is `true` only for tagged releases and `tickets/**` branches, so dependabot PRs build the Dockerfile on both architectures (real coverage for base-image bumps) while the `manifest` job is skipped — satisfying the required check without pushing images or needing registry secrets.
+
+- Update pinned dependencies and pre-commit hooks.
+
 <a id='changelog-0.10.2'></a>
 ## 0.10.2 (2026-06-19)
 

--- a/changelog.d/20260622_000000_jsick_DM_51754.md
+++ b/changelog.d/20260622_000000_jsick_DM_51754.md
@@ -1,3 +1,0 @@
-### Other changes
-
-- The CI `build` job now also runs (without pushing images) for `dependabot/**` pull requests. Previously the Docker build only ran for `tickets/**` branches and releases, so the required `build / manifest` status check was never reported on dependabot PRs and they could not be merged. The reusable build workflow is now passed an explicit `push` expression that is `true` only for tagged releases and `tickets/**` branches, so dependabot PRs build the Dockerfile on both architectures (real coverage for base-image bumps) while the `manifest` job is skipped — satisfying the required check without pushing images or needing registry secrets.

--- a/changelog.d/20260720_141837_jsick_DM_55493.md
+++ b/changelog.d/20260720_141837_jsick_DM_55493.md
@@ -1,3 +1,0 @@
-### Other changes
-
-- Update pinned dependencies and pre-commit hooks.


### PR DESCRIPTION
Prepares the Squarebot 0.10.3 release by collecting the accumulated
`changelog.d/` fragments into `CHANGELOG.md` via `nox -s scriv-collect
0.10.3`, per step 1 of the [release procedure](https://github.com/lsst-sqre/squarebot/blob/main/docs/dev/release.rst).

The dependency-refresh work (#50, DM-55493) is already merged to main; this
PR folds its changelog fragment into the release notes so the release can be
tagged next.

## What this releases

The 0.10.3 entry aggregates two previously-unreleased fragments, both under
**Other changes**:

- **DM-51754** (pre-existing unreleased work): the CI `build` job now also
  runs (without pushing images) for `dependabot/**` pull requests, so the
  required `build / manifest` check is reported on dependabot PRs.
- **DM-55493** (this maintenance round): update pinned dependencies and
  pre-commit hooks.

## Changes

- `CHANGELOG.md`: adds the `## 0.10.3 (2026-07-20)` entry at the
  `<!-- scriv-insert-here -->` marker.
- Deletes the two collected dated fragments; `changelog.d/_template.md` is
  retained.

This is the changelog-collection PR only. Tagging / GitHub release / PyPI
publish follow after this merges.

## References

- Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ