### PR TITLE
DM-55493: fix scriv-collect command in release docs

### DIFF
--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -45,14 +45,14 @@ Run the nox scriv-collect session with the version number you decided on:
 
       .. code-block:: sh
 
-         nox -s scriv-collect X.Y.Z
+         nox -s scriv-collect -- X.Y.Z
 
    .. tab-item:: Without pre-installation
       :sync: uv
 
       .. code-block:: sh
 
-         uv run --only-group=nox nox -s scriv-collect X.Y.Z
+         uv run --only-group=nox nox -s scriv-collect -- X.Y.Z
 
 This will delete the fragment files and collect them into :file:`CHANGELOG.md` under an entry for the new release.
 Review that entry and edit it as needed (proofread, change the order to put more important things first, etc.).


### PR DESCRIPTION
The release docs documented the changelog-collection step as
`nox -s scriv-collect X.Y.Z` (and a `uv run --only-group=nox nox -s
scriv-collect X.Y.Z` variant). That form fails: nox parses the bare
`X.Y.Z` version as a *session name* rather than an argument, e.g.
`Sessions not found: 0.10.3`.

The noxfile's `scriv-collect` session forwards `*session.posargs` to
`scriv collect --add --version`, so the version has to be passed as a
posarg after `--`. This changes both code-block examples to:

- `nox -s scriv-collect -- X.Y.Z`
- `uv run --only-group=nox nox -s scriv-collect -- X.Y.Z`

Docs-only change; no behavior change.

Jira: https://rubinobs.atlassian.net/browse/DM-55493