### PR TITLE
DM-55493: cap fastapi below 0.140 (faststream incompatibility)

### DIFF
--- a/changelog.d/20260727_000000_jsick_DM_55493.md
+++ b/changelog.d/20260727_000000_jsick_DM_55493.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Capped the FastAPI dependency at `<0.140`. FastAPI 0.140.0 made `Dependant` a slots dataclass, which breaks FastStream's FastAPI plugin because it monkey-patches `model`, `custom_fields`, and `flat_params` onto `Dependant` instances (`AttributeError: 'Dependant' object has no attribute 'model' and no __dict__ for setting new attributes`). The cap keeps the next dependency refresh from baking a broken FastAPI into the lockfile, and can be removed once [ag2ai/faststream#2959](https://github.com/ag2ai/faststream/issues/2959) is fixed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,11 @@ classifiers = [
 ]
 requires-python = ">=3.14"
 dependencies = [
-    "fastapi>=0.115",
+    # FastAPI 0.140 made Dependant a slots dataclass; FastStream's FastAPI
+    # plugin monkey-patches attributes onto Dependant instances, which now
+    # raises AttributeError.
+    # TODO: remove when ag2ai/faststream#2959 is fixed
+    "fastapi>=0.115,<0.140",
     "starlette",
     "uvicorn[standard]>=0.30",
     "python-multipart",

--- a/uv.lock
+++ b/uv.lock
@@ -2281,7 +2281,7 @@ typing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastapi", specifier = ">=0.115" },
+    { name = "fastapi", specifier = ">=0.115,<0.140" },
     { name = "faststream", extras = ["kafka"], specifier = ">=0.7,<0.8" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },


### PR DESCRIPTION
## Summary

Cap the direct FastAPI dependency at `<0.140` (`fastapi>=0.115` -> `fastapi>=0.115,<0.140`) so that dependency refreshes can't pull in a FastAPI release that squarebot cannot run on.

## Why

FastAPI 0.140.0 (2026-07-24, [fastapi/fastapi#16049](https://github.com/fastapi/fastapi/pull/16049) "Reduce memory usage in dependencies") changed `Dependant` to `@dataclass(slots=True)`. FastStream's FastAPI plugin monkey-patches `dependant.model`, `.custom_fields` and `.flat_params` onto that instance (`faststream/_internal/fastapi/get_dependant.py:131,135,136`), which now raises:

```
AttributeError: 'Dependant' object has no attribute 'model' and no __dict__ for setting new attributes
```

Upstream bug: [ag2ai/faststream#2959](https://github.com/ag2ai/faststream/issues/2959) — open and unfixed on main (note the repo moved from `airtai/` to `ag2ai/`). faststream 0.7.2 is the latest release and is still affected, and downgrading doesn't help: 0.6.7 carries the same monkey-patch.

Nothing is broken today: the committed `uv.lock` still pins fastapi 0.139.2, so the deployed image and per-PR CI are green. Only the scheduled Periodic CI, which resolves dependencies unpinned, is red. This cap exists so the next `make update` doesn't silently bake 0.140.x into the lockfile and ship a broken image.

Remove the cap (and the `TODO` next to it) once faststream ships a fix.

## Changes

- `pyproject.toml`: `fastapi>=0.115,<0.140`, with a short comment and `# TODO: remove when ag2ai/faststream#2959 is fixed`.
- `uv.lock`: relocked with plain `uv lock` (no `--upgrade`). The only change is the recorded constraint metadata; fastapi stays at **0.139.2** and no other package moved.
- `changelog.d/`: scriv fragment under "Other changes".

## Validation

- `nox -s typing` — mypy clean, 29 source files.
- `nox -s test` — 12 passed (testcontainers Kafka).

Both ran against the locked fastapi 0.139.2 / faststream 0.7.2, i.e. they confirm the cap doesn't disturb the current working set. They do not exercise 0.140 — that combination is known broken and is exactly what the cap excludes.