### PR TITLE
DM-55493: Refresh vendored ruff-shared.toml for ruff 0.16 CPY001

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ python_files = ["tests/*.py", "tests/*/*.py"]
 
 [tool.ruff]
 extend = "ruff-shared.toml"
+target-version = "py314"
 
 [tool.ruff.lint.extend-per-file-ignores]
 "noxfile.py" = [
@@ -153,7 +154,6 @@ extend = "ruff-shared.toml"
 
 [tool.ruff.lint.isort]
 known-first-party = ["squarebot", "rubin.squarebot", "tests"]
-split-on-trailing-comma = false
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -20,7 +20,6 @@
 # Reference for rules: https://docs.astral.sh/ruff/rules/
 exclude = ["docs/**"]
 line-length = 79
-target-version = "py314"
 
 [format]
 docstring-code-format = true
@@ -37,6 +36,7 @@ ignore = [
     "ASYNC240", # we don't want to run filesystem operations on threads
     "BLE001",   # we want to catch and report Exception in background tasks
     "C414",     # nested sorted is how you sort by multiple keys with reverse
+    "CPY001",   # No, every single file doesn't need its own copyright notice
     "D102",     # sometimes we use docstring inheritence
     "D104",     # don't see the point of documenting every package
     "D105",     # our style doesn't require docstrings for magic methods


### PR DESCRIPTION
## Summary

Refreshes squarebot's vendored `ruff-shared.toml` to match the current
`lsst/templates` `fastapi_safir_app` template, which now ignores
`CPY001` (missing-copyright-notice), stabilized out of preview in
ruff 0.16.0.

squarebot's vendored copy carries a deliberate repo-specific
`target-version = "py314"` that a previous campaign consciously
preserved. A verbatim template overwrite would have deleted it, so
this PR moves that pin into `pyproject.toml` `[tool.ruff]` instead,
keeping the vendored file a clean template copy. Confirmed via `ruff
check --show-settings` that ruff still resolves to target version
3.14 after the change.

Also prunes `split-on-trailing-comma = false` from
`pyproject.toml`'s `[tool.ruff.lint.isort]`, since the refreshed
shared file now sets the same value (redundant override).

## Known, out-of-scope finding

`PLR0917` (too-many-positional-arguments), also stabilized in ruff
0.16, now fails on `src/squarebot/services/slack.py:39`
(`SlackService.__init__`, 9 positional args). This is a source-level
fix tracked separately and intentionally left untouched here — this
PR is config-only.

## References

- Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ