### PR TITLE
DM-55493: scope PLR0917 for ruff 0.16

### DIFF
--- a/src/squarebot/services/slack.py
+++ b/src/squarebot/services/slack.py
@@ -38,6 +38,7 @@ class SlackService:
 
     def __init__(
         self,
+        *,
         logger: BoundLogger,
         config: Configuration,
         app_mentions_publisher: DefaultPublisher,


### PR DESCRIPTION
## Background

Ruff 0.16.0 stabilized `PLR0917` (`too-many-positional-arguments`), which was
previously in preview and therefore invisible to the version pinned in our
`.pre-commit-config.yaml`. With the rule now stable, `uvx ruff@0.16.0 check`
reports exactly one violation in this repo:

```
PLR0917 Too many positional arguments (9 > 5)
  --> src/squarebot/services/slack.py:39:9
```

`SlackService.__init__` takes `logger`, `config`, and **seven**
`DefaultPublisher` instances — `app_mentions`, `channel`, `groups`, `im`,
`mpim`, `block_actions`, and `view_submission`.

## Why fix rather than scope an ignore

This is the textbook case the rule exists to catch. The seven publisher
parameters share a single type (`DefaultPublisher`), so a positional call
that transposed, say, `groups_publisher` and `im_publisher` would type-check
cleanly, pass review, and then silently route Slack group messages onto the
IM Kafka topic. There is no positional call ordering here that a reader could
verify at a glance, so suppressing the warning would be discarding a real
signal rather than quieting a false positive.

## The change

One line: a bare `*,` inserted after `self`, making all nine parameters
keyword-only.

```python
 def __init__(
     self,
+    *,
     logger: BoundLogger,
     config: Configuration,
     app_mentions_publisher: DefaultPublisher,
     ...
```

No parameters are removed, renamed, or reordered, and no `noqa` is added.
This also brings `SlackService` in line with `Factory.__init__`, which is
already keyword-only.

## Call sites

I grepped `SlackService` and `super().__init__(` across `src/`, `tests/`, and
the `client/` subpackage. There is exactly one construction site:

- `src/squarebot/factory.py:98` — `Factory.create_slack_service`, which
  already passes **all nine arguments by keyword**.

So no caller changes were required. `SlackService` has no subclasses, so
there are no `super().__init__()` calls to fix. The other reference,
`tests/support/slackrequester.py:82`, calls the `compute_slack_signature`
staticmethod and is unaffected by the constructor signature.

## Validation

- `nox -s typing test` — both sessions pass (mypy clean; 12 tests passed).
  A signature change that broke the caller would surface here, since
  `factory.py` reaches 100% coverage.
- `uvx ruff@0.16.0 check --select PLR0917,ISC004 .` — was 1 error, now
  **All checks passed!** (No `ISC004` violations existed before or after.)
- `uvx ruff@0.16.0 check .` under the repo's full config — all checks passed.
- pre-commit `ruff check` / `ruff format` hooks pass.

No changelog fragment: `SlackService` is an internal service constructed only
by the app's own `Factory`. It is not part of the published `rubin-squarebot`
client API, so this is not a user-visible change.

## References

Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)


[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ