### PR TITLE
DM-55725: Adopt faststream_fastapi for the Kafka FastAPI integration

### DIFF
--- a/changelog.d/20260805_000000_jsick_DM_55725.md
+++ b/changelog.d/20260805_000000_jsick_DM_55725.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Adopted [`faststream_fastapi`](https://faststream-community.github.io/faststream_fastapi/) in place of FastStream's now-deprecated built-in FastAPI plugin (`faststream.kafka.fastapi.KafkaRouter`). The Kafka broker now hangs off a plain `KafkaBroker`, and `FastStreamAPI` wraps the FastAPI app to start/stop the broker around its lifespan. This also lifts the `fastapi<0.140` cap that was needed to work around the deprecated plugin.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,18 +19,15 @@ classifiers = [
 ]
 requires-python = ">=3.14"
 dependencies = [
-    # FastAPI 0.140 made Dependant a slots dataclass; FastStream's FastAPI
-    # plugin monkey-patches attributes onto Dependant instances, which now
-    # raises AttributeError.
-    # TODO: remove when ag2ai/faststream#2959 is fixed
-    "fastapi>=0.115,<0.140",
+    "fastapi>=0.115,<1",
     "starlette",
     "uvicorn[standard]>=0.30",
     "python-multipart",
     "pydantic>=2",
     "pydantic-settings>=2.14.2",
     "safir>=13",
-    "faststream[kafka]>=0.7,<0.8",
+    "faststream[kafka]>=0.7.3,<0.8",
+    "faststream-fastapi>=1.2.1,<2",
     "rubin-squarebot",
 ]
 dynamic = ["version"]

--- a/src/squarebot/factory.py
+++ b/src/squarebot/factory.py
@@ -10,7 +10,7 @@ from faststream.kafka.publisher import DefaultPublisher
 from structlog.stdlib import BoundLogger
 
 from .config import config
-from .kafkarouter import kafka_router
+from .kafkarouter import kafka_broker
 from .services.slack import SlackService
 
 
@@ -21,7 +21,7 @@ class ProcessContext:
     """
 
     kafka_broker: KafkaBroker
-    """The aiokafka broker provided through the FastStream Kafka router."""
+    """The aiokafka broker provided through the FastStream Kafka broker."""
 
     channel_publisher: DefaultPublisher
     """A Kafka publisher for the message channels topic."""
@@ -46,7 +46,7 @@ class ProcessContext:
 
     @classmethod
     async def create(cls) -> Self:
-        broker = kafka_router.broker
+        broker = kafka_broker
         return cls(
             kafka_broker=broker,
             channel_publisher=broker.publisher(

--- a/src/squarebot/kafkarouter.py
+++ b/src/squarebot/kafkarouter.py
@@ -1,18 +1,24 @@
-"""The FastStream Kafka router for SQuaRE Bot."""
+"""The FastStream Kafka broker for SQuaRE Bot."""
 
 from __future__ import annotations
 
-from faststream.kafka.fastapi import KafkaRouter
+from faststream.kafka import KafkaBroker
 from faststream.security import BaseSecurity
 
 from .config import config
 
-__all__ = ["kafka_router"]
+__all__ = ["kafka_broker"]
 
 
+# Hand-rolled BaseSecurity wiring is kept as-is here (not normalized to
+# safir.kafka.KafkaConnectionSettings) because squarebot's own
+# KafkaConnectionSettings (config.py) exposes ``cert_temp_dir``,
+# ``client_ca_path``, and ``client_key_password`` fields/env vars for
+# Strimzi-style client-cert concatenation that safir's version does not
+# have, and safir's settings model uses ``extra="forbid"``. Adopting it
+# could silently drop support for those env vars if Phalanx ever sets them.
 kafka_security = BaseSecurity(ssl_context=config.kafka.ssl_context)
-kafka_router = KafkaRouter(
+kafka_broker = KafkaBroker(
     config.kafka.bootstrap_servers,
     security=kafka_security,
-    schema_url=f"{config.path_prefix}/asyncapi",
 )

--- a/src/squarebot/main.py
+++ b/src/squarebot/main.py
@@ -16,6 +16,7 @@ from importlib.metadata import metadata, version
 
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
+from faststream_fastapi import FastStreamAPI
 from safir.dependencies.http_client import http_client_dependency
 from safir.logging import configure_logging, configure_uvicorn_logging
 from safir.middleware.x_forwarded import XForwardedMiddleware
@@ -25,14 +26,21 @@ from .config import config
 from .dependencies.requestcontext import context_dependency
 from .handlers.external.handlers import external_router
 from .handlers.internal.handlers import internal_router
-from .kafkarouter import kafka_router
+from .kafkarouter import kafka_broker
 
 __all__ = ["app", "create_openapi"]
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    """Set up and tear down the application."""
+async def lifespan(fastapi_app: FastAPI) -> AsyncIterator[None]:
+    """Set up and tear down the application.
+
+    Note
+    ----
+    The FastStream Kafka broker is started and stopped by ``FastStreamAPI``
+    around this lifespan, so by the time this runs the broker is already
+    connected.
+    """
     # Any code here will be run when the application starts up.
     logger = get_logger()
     logger.info("Square Bot is starting up.")
@@ -51,17 +59,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     await context_dependency.initialize()
 
-    # Start the FastStream Kafka broker directly rather than via
-    # ``kafka_router.lifespan_context``. As of FastStream 0.7 the router's
-    # lifespan context is one-shot: it stops the broker on exit but does not
-    # restart it if the lifespan is entered again, whereas ``broker.start()``
-    # and ``broker.stop()`` are re-callable. The test suite drives the app
-    # lifespan once per test against the module-level app, so the broker must
-    # restart cleanly between tests.
-    await kafka_router.broker.start()
     logger.info("Square Bot start up complete.")
     yield
-    await kafka_router.broker.stop()
 
     # Any code here will be run when the application shuts down.
     await http_client_dependency.aclose()
@@ -76,7 +75,7 @@ configure_logging(
 )
 configure_uvicorn_logging(config.log_level)
 
-app = FastAPI(
+fastapi_app = FastAPI(
     title="SQuaRE Bot",
     description=metadata("squarebot")["Summary"],
     version=version("squarebot"),
@@ -85,23 +84,33 @@ app = FastAPI(
     redoc_url=f"{config.path_prefix}/redoc",
     lifespan=lifespan,
 )
-"""The main FastAPI application for squarebot."""
+"""The inner FastAPI application for squarebot."""
 
 # Attach the routers.
-app.include_router(internal_router)
-app.include_router(external_router, prefix=config.path_prefix)
-app.include_router(kafka_router)
+fastapi_app.include_router(internal_router)
+fastapi_app.include_router(external_router, prefix=config.path_prefix)
 
 # Set up middleware
-app.add_middleware(XForwardedMiddleware)
+fastapi_app.add_middleware(XForwardedMiddleware)
+
+# Wrap the FastAPI app with the FastStream Kafka broker. This must come
+# after all subscriber modules are imported (none are used by squarebot
+# today, but the broker is still owned here so publishers share its
+# connection).
+app = FastStreamAPI(
+    kafka_broker,
+    application=fastapi_app,
+    asyncapi_path=f"{config.path_prefix}/asyncapi",
+)
+"""The ASGI application for squarebot, serving both HTTP and Kafka."""
 
 
 def create_openapi() -> str:
     """Create the OpenAPI spec for static documentation."""
     spec = get_openapi(
-        title=app.title,
-        version=app.version,
-        description=app.description,
-        routes=app.routes,
+        title=fastapi_app.title,
+        version=fastapi_app.version,
+        description=fastapi_app.description,
+        routes=fastapi_app.routes,
     )
     return json.dumps(spec)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,18 +8,19 @@ from pathlib import Path
 import pytest
 import pytest_asyncio
 from asgi_lifespan import LifespanManager
-from fastapi import FastAPI
+from faststream_fastapi import FastStreamAPI
 from httpx import ASGITransport, AsyncClient
 
 from squarebot import main
 
 
 @pytest_asyncio.fixture
-async def app() -> AsyncIterator[FastAPI]:
+async def app() -> AsyncIterator[FastStreamAPI]:
     """Return a configured test application.
 
     Wraps the application in a lifespan manager so that startup and shutdown
-    events are sent during test execution.
+    events are sent during test execution. This also starts and stops the
+    Kafka broker around the app's own lifespan.
     """
     async with LifespanManager(main.app):
         yield main.app
@@ -32,7 +33,7 @@ async def http_client() -> AsyncIterator[AsyncClient]:
 
 
 @pytest_asyncio.fixture
-async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
+async def client(app: FastStreamAPI) -> AsyncIterator[AsyncClient]:
     """Return an ``httpx.AsyncClient`` configured to talk to the test app."""
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="https://example.com/"

--- a/uv.lock
+++ b/uv.lock
@@ -614,21 +614,34 @@ wheels = [
 
 [[package]]
 name = "faststream"
-version = "0.7.2"
+version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "fast-depends", extra = ["pydantic"] },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/bf/41ed52f57a2e7552982b0772fd4aa3bd381ecc4addb181c52dbf41d4189d/faststream-0.7.2.tar.gz", hash = "sha256:ff03f3e8435f64e033f669bb52faf6731b2d87572d42cc0f6113dff1a46211d4", size = 332093, upload-time = "2026-07-14T12:45:04.948Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/fc/1e817ff0c5fe4bf992473b5179e3e5e892624fb68cf91eeabc20dcbdc2bb/faststream-0.7.3.tar.gz", hash = "sha256:f53015a6eedd11bfecf31ce63d7d650eb19c4ee7a009c3e0583392674fb67535", size = 333766, upload-time = "2026-07-28T20:47:57.442Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/af/34a2f255c36c6bedd59b63b84eb05a59f1398c31a77f98edfcd1421a9080/faststream-0.7.2-py3-none-any.whl", hash = "sha256:5c6130493855c57758d48a434f54cc887c734f5cba7b19632e323daf3bc516ea", size = 559352, upload-time = "2026-07-14T12:45:03.382Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/cc/f4deb57be7349adc0f0e8a133e937b13bac2737fcbaaae5353bba48d8df3/faststream-0.7.3-py3-none-any.whl", hash = "sha256:10e6b5cf46aea1fe0be0112b99607c85b6bd56f8e448ebb68e8c56cad165a325", size = 561336, upload-time = "2026-07-28T20:47:55.861Z" },
 ]
 
 [package.optional-dependencies]
 kafka = [
     { name = "aiokafka" },
+]
+
+[[package]]
+name = "faststream-fastapi"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastapi" },
+    { name = "faststream" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/59/76b140ed8d6f66e9e8b8e1f5f341ee8b24376356ba712cab904be9670319/faststream_fastapi-1.2.1.tar.gz", hash = "sha256:f34e39439bb008dd8df3a616d41ca2dda2cd76726585476f204526e1f76bda1e", size = 12239, upload-time = "2026-07-30T10:25:03.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/4c/2e80037d4fc563148dd06ac01e72a09a6b8a90e9a7687db7a060f57a24b5/faststream_fastapi-1.2.1-py3-none-any.whl", hash = "sha256:f1fec6f8de29f72289065308d4f3954b60d4e36c5f04d3b09f62152a461e9af8", size = 19923, upload-time = "2026-07-30T10:25:02.397Z" },
 ]
 
 [[package]]
@@ -2226,6 +2239,7 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "faststream", extra = ["kafka"] },
+    { name = "faststream-fastapi" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
@@ -2263,8 +2277,9 @@ typing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastapi", specifier = ">=0.115,<0.140" },
-    { name = "faststream", extras = ["kafka"], specifier = ">=0.7,<0.8" },
+    { name = "fastapi", specifier = ">=0.115,<1" },
+    { name = "faststream", extras = ["kafka"], specifier = ">=0.7.3,<0.8" },
+    { name = "faststream-fastapi", specifier = ">=1.2.1,<2" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "python-multipart" },


### PR DESCRIPTION
Jira: [DM-55725](https://rubinobs.atlassian.net/browse/DM-55725)

## Summary

FastStream 0.7.3 deprecated its built-in FastAPI plugin (`faststream.kafka.fastapi.KafkaRouter`, see [ag2ai/faststream#2944](https://github.com/ag2ai/faststream/issues/2944)); it will be removed in FastStream 1.0.0. This adopts the successor, [`faststream_fastapi`](https://faststream-community.github.io/faststream_fastapi/), which inverts the integration: subscribers/publishers hang off a plain `faststream.kafka.KafkaBroker`, and `FastStreamAPI(broker, application=fastapi_app)` wraps the FastAPI app as the ASGI entrypoint, starting/stopping the broker around the app's own lifespan.

Proven on the [unfurlbot pilot](https://github.com/lsst-sqre/unfurlbot/pull/43).

## Changes

- `src/squarebot/kafkarouter.py`: `KafkaRouter` → `KafkaBroker` (`kafka_router` → `kafka_broker`).
- `src/squarebot/factory.py`: publishers are built off the module-level `kafka_broker`, same shape as before (drop-in, no second broker constructed).
- `src/squarebot/main.py`: the inner FastAPI instance is now named `fastapi_app`; `FastStreamAPI` wraps it as `app` (the uvicorn/Dockerfile entrypoint `squarebot.main:app` is unchanged). The explicit `kafka_router.broker.start()`/`.stop()` calls in `lifespan` are removed — `FastStreamAPI` now owns broker startup/shutdown around the app lifespan. `asyncapi_path` moved from the old router's `schema_url` onto `FastStreamAPI`.
- `tests/conftest.py`: the `app` fixture now types as `FastStreamAPI`; `LifespanManager` wraps it so broker startup is exercised in tests same as before.
- `pyproject.toml`: added `faststream-fastapi>=1.2.1,<2`; bumped `faststream[kafka]` floor to `>=0.7.3,<0.8`; lifted the `fastapi<0.140` cap (and removed the associated `ag2ai/faststream#2959` TODO comment) back to `fastapi>=0.115,<1`.
- `uv.lock` refreshed for the above.
- `changelog.d/20260805_000000_jsick_DM_55725.md` added.

## Config normalization — skipped

squarebot's Kafka connection is hand-rolled (`BaseSecurity(ssl_context=...)` in `kafkarouter.py`, `bootstrap_servers` + `ssl_context` built manually in `config.py`), and the playbook's step 3 offers normalizing it to `safir.kafka.KafkaConnectionSettings`. I left it as-is: squarebot's own `KafkaConnectionSettings` exposes `cert_temp_dir`, `client_ca_path`, and `client_key_password` fields/env vars (`KAFKA_CERT_TEMP_DIR`, `KAFKA_CLIENT_CA_PATH`, `KAFKA_CLIENT_KEY_PASSWORD`) for Strimzi-style client-cert-plus-CA concatenation that safir's `KafkaConnectionSettings` does not support, and safir's settings model uses `extra="forbid"`. Adopting it could silently break config loading (or drop support for those env vars) if Phalanx sets them. A Phalanx values/secrets audit + rename is out of scope for this worker; flagging it here in case it's worth a follow-up.

## Publisher wiring — left unchanged

`factory.py` already built its publishers off `kafka_router.broker` directly (no second broker), so no refactor was needed there — it now reads `kafka_broker` in the identical shape.

## Validation

- `uv run --only-group=nox nox -s typing test` — mypy clean, 12/12 tests pass (server test suite runs against a real testcontainers Kafka broker).
- `uv run --only-group=nox nox -s lint` — prek/ruff clean.
- Detection check: `git grep -nE 'faststream\.[a-z]+\.fastapi' -- src tests` returns nothing; `faststream-fastapi` is declared in `pyproject.toml`; no `<0.140` string remains.
- Smoke: `python -W error::DeprecationWarning -c "import squarebot.main"` does not raise.

[DM-55725]: https://rubinobs.atlassian.net/browse/DM-55725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ